### PR TITLE
Add boolean function for modinverse (OSK-5)

### DIFF
--- a/src/OSK.Math.Polynomials/Exceptions/ModInverseException.cs
+++ b/src/OSK.Math.Polynomials/Exceptions/ModInverseException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace OSK.Math.Polynomials.Exceptions
+{
+    public class ModInverseException: InvalidOperationException
+    {
+        public ModInverseException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/OSK.Math.Polynomials/MathUtilities.cs
+++ b/src/OSK.Math.Polynomials/MathUtilities.cs
@@ -1,4 +1,5 @@
 ﻿using Fractions;
+using OSK.Math.Polynomials.Exceptions;
 using OSK.Math.Polynomials.Models;
 using System;
 using System.Numerics;
@@ -43,12 +44,26 @@ namespace OSK.Math.Polynomials
             var result = EGcd(fraction.Denominator, modulo);
             if (result.Gcd != 1)
             {
-                throw new InvalidOperationException("The modular inverse does not exist.");
+                throw new ModInverseException($"The modular inverse between {fraction.Denominator} and {modulo} does not exist.");
             }
 
             var mod = result.U % modulo;
             var inverseResult = mod * fraction.Numerator % modulo;
             return inverseResult < 0 ? inverseResult + modulo : inverseResult;
+        }
+
+        public static bool TryModInverse(Fraction fraction, int modulo, out Fraction result)
+        {
+            var gcdResult = EGcd(fraction.Denominator, modulo);
+            result = default;
+            if (gcdResult.Gcd == 1)
+            {
+                var mod = gcdResult.U % modulo;
+                var inverseResult = mod * fraction.Numerator % modulo;
+                result = inverseResult < 0 ? inverseResult + modulo : inverseResult;
+            }
+
+            return gcdResult.Gcd == 1;
         }
     }
 }

--- a/src/OSK.Math.Polynomials/PolynomialMath.cs
+++ b/src/OSK.Math.Polynomials/PolynomialMath.cs
@@ -1,4 +1,5 @@
 ﻿using Fractions;
+using OSK.Math.Polynomials.Exceptions;
 using OSK.Math.Polynomials.Models;
 using System;
 using System.Collections.Generic;
@@ -280,7 +281,7 @@ namespace OSK.Math.Polynomials
         {
             if (modulo == 0)
             {
-                throw new InvalidOperationException($"Modulo can not be 0.");
+                throw new ModInverseException($"Modulo can not be 0.");
             }
 
             polynomial.Pack();
@@ -293,6 +294,30 @@ namespace OSK.Math.Polynomials
 
             result.Pack();
             return result;
+        }
+
+        public static bool TryModInverse(Polynomial polynomial, int modulo, out Polynomial result)
+        {
+            if (modulo == 0)
+            {
+                throw new ModInverseException($"Modulo can not be 0.");
+            }
+
+            polynomial.Pack();
+
+            result = new Polynomial(polynomial.TotalCoeffecients);
+            for (var i = 0; i < result.Length; i++)
+            {
+                if (!MathUtilities.TryModInverse(polynomial[i].Coeffecient, modulo, out var inverse))
+                {
+                    result = null;
+                    return false;
+                }
+                result[i] = new PolynomialTerm(inverse, result[i].Exponent);
+            }
+
+            result.Pack();
+            return true;
         }
 
         #endregion


### PR DESCRIPTION
Motivation
----
In cases where throwing an exception should be avoided, adding a Try method to return a boolean result

Modifications
----
* Updated MathUtilities to use a new TryModInverse for fractions and added similar method to PolynomialMath
* Added new ModInverseException for a more specific error, inheriting from invalid operation exception

Result
----
New try method is available

Fixes #5