### PR TITLE
Fix polynomial degree lookup error (OSK-7)

### DIFF
--- a/src/OSK.Math.Polynomials.UnitTests/PolynomialMathTests.cs
+++ b/src/OSK.Math.Polynomials.UnitTests/PolynomialMathTests.cs
@@ -373,6 +373,88 @@ namespace OSK.Math.Polynomials.UnitTests
 
         #endregion
 
+        #region ModRemainder
+
+        [Fact]
+        public void ModRemainder_SmallerDivisor_ReturnsExpected()
+        {
+            // Arrange
+            
+            // -22x - 16x^2 + 25x^3 + 38x^4 + 32x^5 + 51x^6 + 44x^7 + 38x^8 + 16x^9
+            var dividend = new Polynomial(0, -22, -16, 25, 37, 32, 51, 44, 38, 16);
+
+            // -1 + x^7
+            var divisor = new Polynomial(-1, 0, 0, 0, 0, 0, 0, 1);
+
+            // Act
+            var result = PolynomialMath.ModRemainder(dividend, divisor, 41);
+
+            // Assert
+
+            // Expected: 3 + 16x + 25x^3 + 37x^4 + 32x^5 + 10x^6
+            var expectedPolynomial = new Polynomial(3, 16, 0, 25, 37, 32, 10);
+
+            Assert.Equal(expectedPolynomial, result);
+        }
+
+        #endregion
+
+        #region ModInverse
+
+        [Fact]
+        public void ModInverse_PolynomialHasLessCoeffecientsThanDegree_ReturnsExpected()
+        {
+            // Arrange
+
+            // x + 2x^5
+            var dividend = new Polynomial(0, 1, 0, 0, 0, 2);
+
+            // Act
+            var result = PolynomialMath.ModInverse(dividend, 41);
+
+            // Assert
+
+            // Expected: x + 2x^5
+            Assert.Equal(2, result.Length);
+
+            var polynomialTerm = result[0];
+            Assert.Equal(1, polynomialTerm.Exponent);
+            Assert.Equal(1, polynomialTerm.Coeffecient);
+
+            polynomialTerm = result[1];
+            Assert.Equal(5, polynomialTerm.Exponent);
+            Assert.Equal(2, polynomialTerm.Coeffecient);
+        }
+
+        #endregion
+
+        #region TryModInverse
+
+        [Fact]
+        public void TryModInverse_PolynomialHasLessCoeffecientsThanDegree_ReturnsExpected()
+        {
+            // Arrange
+
+            // x + 2x^5
+            var test = new Polynomial(0, 1, 0, 0, 0, 2);
+
+            // Act
+            var result = PolynomialMath.TryModInverse(test, 41, out var polynomial);
+
+            // Assert
+            Assert.True(result);
+
+            var polynomialTerm = polynomial[0];
+            Assert.Equal(1, polynomialTerm.Exponent);
+            Assert.Equal(1, polynomialTerm.Coeffecient);
+
+            polynomialTerm = polynomial[1];
+            Assert.Equal(5, polynomialTerm.Exponent);
+            Assert.Equal(2, polynomialTerm.Coeffecient);
+        }
+
+        #endregion
+
         #region Extended Euclidean
 
         [Fact]

--- a/src/OSK.Math.Polynomials.UnitTests/PolynomialTests.cs
+++ b/src/OSK.Math.Polynomials.UnitTests/PolynomialTests.cs
@@ -54,6 +54,77 @@ namespace OSK.Math.Polynomials.UnitTests
 
         #endregion
 
+        #region GetPolynomialTermByDegree
+
+        [Fact]
+        public void GetPolynomialTermByDegree_IndexLessThan0_ThrowsIndexOutOfRangeException()
+        {
+            // Arrange
+            var polynomial = new Polynomial(1, 0, 0, 0, 1, 1); // 1 + x^4 + x^5
+            polynomial.Pack();
+
+            // Act/Assert
+            Assert.Throws<IndexOutOfRangeException>(() => polynomial.GetPolynomialTermByDegree(-1));
+        }
+
+
+        [Fact]
+        public void GetPolynomialTermByDegree_IndexGreaerThanPolynomialLength_ThrowsIndexOutOfRangeException()
+        {
+            // Arrange
+            var polynomial = new Polynomial(1, 0, 0, 0, 1, 1); // 1 + x^4 + x^5
+            polynomial.Pack();
+
+            // Act/Assert
+            Assert.Throws<IndexOutOfRangeException>(() => polynomial.GetPolynomialTermByDegree(6));
+        }
+
+        [Fact]
+        public void GetPolynomialTermByDegree_NotPacked_DegreeWithinPolynomial_ReturnsZeroPolynomialTerm()
+        {
+            // Arrange
+            var polynomial = new Polynomial(1, 0, 0, 0, 1, 1); // 1 + x^4 + x^5
+
+            // Act
+            var term = polynomial.GetPolynomialTermByDegree(3);
+
+            // Assert
+            Assert.Equal(3, term.Exponent);
+            Assert.Equal(0, term.Coeffecient);
+        }
+
+        [Fact]
+        public void GetPolynomialTermByDegree_Packed_DegreeWithinPolynomialButMissingCoeffecient_ReturnsZeroPolynomialTerm()
+        {
+            // Arrange
+            var polynomial = new Polynomial(1, 0, 0, 0, 1, 1); // 1 + x^4 + x^5
+            polynomial.Pack();
+
+            // Act
+            var term = polynomial.GetPolynomialTermByDegree(3);
+
+            // Assert
+            Assert.Equal(3, term.Exponent);
+            Assert.Equal(0, term.Coeffecient);
+        }
+
+        [Fact]
+        public void GetPolynomialTermByDegree_Packed_DegreeWithinPolynomialIsIndexed_ReturnsExpectedPolynomialTerm()
+        {
+            // Arrange
+            var polynomial = new Polynomial(1, 0, 0, 0, 1, 1, 0, 1, 116, 2); // 1 + x^4 + x^5 + x7 + 116x^8 + 2x^9
+            polynomial.Pack();
+
+            // Act
+            var term = polynomial.GetPolynomialTermByDegree(8);
+
+            // Assert
+            Assert.Equal(8, term.Exponent);
+            Assert.Equal(116, term.Coeffecient);
+        }
+
+        #endregion
+
         #region ToString
 
         [Fact]

--- a/src/OSK.Math.Polynomials/Polynomial.cs
+++ b/src/OSK.Math.Polynomials/Polynomial.cs
@@ -160,12 +160,14 @@ namespace OSK.Math.Polynomials
             {
                 throw new IndexOutOfRangeException($"The provided polynomial term degree, {degree}, is outside the degree of the polynomial.");
             }
-            if (_polynomialIndexLookupByDegree.TryGetValue(degree, out var polynomialTermIndex))
+            if (_isPacked)
             {
-                return _polynomialTerms[polynomialTermIndex];
+                return _polynomialIndexLookupByDegree.TryGetValue(degree, out var polynomialTermIndex)
+                    ? _polynomialTerms[polynomialTermIndex]
+                    : new PolynomialTerm(0, 1, degree);
             }
 
-            for (var i = 0; i < degree; i++)
+            for (var i = 0; i < Length; i++)
             {
                 if (_polynomialTerms[i].Exponent == degree)
                 {
@@ -173,7 +175,7 @@ namespace OSK.Math.Polynomials
                 }
             }
 
-            return new PolynomialTerm(0, 1, Degree);
+            return new PolynomialTerm(0, 1, degree);
         }
 
         #endregion

--- a/src/OSK.Math.Polynomials/PolynomialMath.cs
+++ b/src/OSK.Math.Polynomials/PolynomialMath.cs
@@ -289,7 +289,8 @@ namespace OSK.Math.Polynomials
             var result = new Polynomial(polynomial.TotalCoeffecients);
             for (var i = 0; i < result.Length; i++)
             {
-                result[i] = new PolynomialTerm(MathUtilities.ModInverse(polynomial[i].Coeffecient, modulo), result[i].Exponent);
+                var polynomialTerm = polynomial.GetPolynomialTermByDegree(i);
+                result[i] = new PolynomialTerm(MathUtilities.ModInverse(polynomialTerm.Coeffecient, modulo), result[i].Exponent);
             }
 
             result.Pack();
@@ -308,7 +309,8 @@ namespace OSK.Math.Polynomials
             result = new Polynomial(polynomial.TotalCoeffecients);
             for (var i = 0; i < result.Length; i++)
             {
-                if (!MathUtilities.TryModInverse(polynomial[i].Coeffecient, modulo, out var inverse))
+                var polynomialTerm = polynomial.GetPolynomialTermByDegree(i);
+                if (!MathUtilities.TryModInverse(polynomialTerm.Coeffecient, modulo, out var inverse))
                 {
                     result = null;
                     return false;


### PR DESCRIPTION
Motivation
----
Some PolynomialMath and polynomial index functions are failing due to index lookups not properly accounting for packing, when they should be

Modifications
----
* Adjusted Polynomial get by degree method to better handle lookups when in either a pack or unpacked state
* Updated PolynomialMath to use the correct method for a couple of functions using a direct indexer by mistake
* Updated UnitTests to catch current known issues

Result
----
Polynomial math and index lookps work as expected

Fixes #7